### PR TITLE
Cells

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,3 +50,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'cells-rails'
+gem 'cells-erb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,12 +66,28 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    cells (4.1.7)
+      declarative-builder (< 0.2.0)
+      declarative-option (< 0.2.0)
+      tilt (>= 1.4, < 3)
+      uber (< 0.2.0)
+    cells-erb (0.1.0)
+      cells (~> 4.0)
+      erbse (>= 0.1.1)
+    cells-rails (0.1.3)
+      actionpack (>= 5.0)
+      cells (>= 4.1.6, < 5.0.0)
     code_analyzer (0.5.2)
       sexp_processor
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    declarative-builder (0.1.0)
+      declarative-option (< 0.2.0)
+    declarative-option (0.1.0)
     diff-lcs (1.4.4)
+    erbse (0.1.4)
+      temple
     erubi (1.10.0)
     erubis (2.7.0)
     ffi (1.14.2)
@@ -212,6 +228,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.8.2)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -220,6 +237,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    uber (0.1.0)
     unicode-display_width (2.0.0)
     uniform_notifier (1.13.2)
     web-console (4.1.0)
@@ -244,6 +262,8 @@ DEPENDENCIES
   brakeman
   bullet
   byebug
+  cells-erb
+  cells-rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)


### PR DESCRIPTION
# 実装したこと
* cellsの導入
# 実装した理由
* 一つのコントローラーに複数のモデルに関するロジックを記入しないで、モデルごとにビューファイルのロジックが記述できるようにするため。