### PR TITLE
Rails-i18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ gem 'cells-erb'
 gem 'active_hash'
 
 gem 'devise'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_best_practices (1.20.0)
       activesupport
       code_analyzer (>= 0.5.1)
@@ -287,6 +290,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
+  rails-i18n
   rails_best_practices
   rspec-rails (~> 4.0.0)
   rubocop


### PR DESCRIPTION
# 実装したこと
* rails-i18nの導入
# 実装した理由
* deviseなどを用いた際の、デフォルトのメッセージやエラーの表記を日本語に対応させるため