### PR TITLE
Factory_bot_rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development do
   gem 'bullet'
   gem 'pry-rails'
   gem 'rails_best_practices', require: false
+  gem 'factory_bot_rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,11 @@ GEM
       temple
     erubi (1.10.0)
     erubis (2.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -284,6 +289,7 @@ DEPENDENCIES
   cells-erb
   cells-rails
   devise
+  factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)


### PR DESCRIPTION
# 実装したこと
* factory_bot_railsの導入
# 実装した理由
* アプリケーションの各モデルのインスタンスを、テストの際に事前に作成して、モデルごとに管理するため